### PR TITLE
Preventing redundant computations

### DIFF
--- a/cpp/KineticGas.cpp
+++ b/cpp/KineticGas.cpp
@@ -107,7 +107,6 @@ std::vector<double> KineticGas::get_K_prime_factors(double rho, double T, const 
 
 std::vector<std::vector<double>> KineticGas::get_conductivity_matrix(double rho, double T, const std::vector<double>& x, int N){
     std::vector<std::vector<double>> rdf = get_rdf(rho, T, x);
-    std::vector<double> K = get_K_factors(rho, T, x);
     std::vector<std::vector<double>> matr(N * Ncomps, std::vector<double>(N * Ncomps, 0.));
     std::vector<double> wt_fracs = get_wt_fracs(x);
 
@@ -169,9 +168,7 @@ std::vector<double> KineticGas::get_conductivity_vector(double rho, double T, co
 
 std::vector<std::vector<double>> KineticGas::get_diffusion_matrix(double rho, double T, const std::vector<double>& x, int N){
     std::vector<std::vector<double>> rdf = get_rdf(rho, T, x);
-    std::vector<double> K_fact = get_K_factors(rho, T, x);
     std::vector<std::vector<double>> matr(N*pow(Ncomps, 2), std::vector<double>(N*pow(Ncomps, 2), 0.));
-    std::vector<std::vector<double>> d = get_contact_diameters(rho, T, x);
     std::vector<double> wt_fracs = get_wt_fracs(x);
 
     precompute_diffusion_omega(N, T); // Compute all the collision integrals required for this diffusion matrix


### PR DESCRIPTION
Diffusion coefficients were doing unnecessary, expensive, computations.