### PR TITLE
Init with params

### DIFF
--- a/docs/vCurrent/MieKinGas_methods.md
+++ b/docs/vCurrent/MieKinGas_methods.md
@@ -6,7 +6,7 @@ permalink: /vcurrent/MieKinGas_methods.html
 ---
 
 <!--- 
-Generated at: 2023-11-06T12:02:00.296867
+Generated at: 2024-04-18T17:40:59.602391
 This is an auto-generated file, generated using the script at KineticGas/pyUtils/markdown_from_docstrings.py
 The file is created by parsing the docstrings of the methods in the 
 MieKinGas class. For instructions on how to use the parser routines, see the
@@ -17,7 +17,14 @@ RET-Mie Model. This class implements utility methods to access mixing parameters
 
 ## Table of contents
   * [Constructor](#constructor)
-    * [\_\_init\_\_](#__init__self-comps-mole_weightsnone-sigmanone-eps_div_knone-lanone-lrnone-lij0-kij0-n4-is_idealgasfalse-use_eosnone-parameter_refdefault)
+    * [\_\_init\_\_](#__init__self-comps-mole_weightsnone-sigmanone-eps_div_knone-lanone-lrnone-lij0-kij0-n4-is_idealgasfalse-use_eosnone-parameter_refdefault-use_default_eos_paramfalse)
+  * [Utility methods](#utility-methods)
+    * [set_eps_div_k](#set_eps_div_kself-eps_div_k-update_eostrue)
+    * [set_la](#set_laself-la-update_eostrue)
+    * [set_lr](#set_lrself-lr-update_eostrue)
+    * [set_sigma](#set_sigmaself-sigma-update_eostrue)
+  * [Internal methods](#internal-methods)
+    * [\_\_update_cpp_kingas_param\_\_](#__update_cpp_kingas_param__self)
 
 ## Constructor
 
@@ -25,10 +32,10 @@ Methods to initialise RET-Mie model.
 
 ### Table of contents
   * [Constructor](#constructor)
-    * [\_\_init\_\_](#__init__self-comps-mole_weightsnone-sigmanone-eps_div_knone-lanone-lrnone-lij0-kij0-n4-is_idealgasfalse-use_eosnone-parameter_refdefault)
+    * [\_\_init\_\_](#__init__self-comps-mole_weightsnone-sigmanone-eps_div_knone-lanone-lrnone-lij0-kij0-n4-is_idealgasfalse-use_eosnone-parameter_refdefault-use_default_eos_paramfalse)
 
 
-### `__init__(self, comps, mole_weights=None, sigma=None, eps_div_k=None, la=None, lr=None, lij=0, kij=0, N=4, is_idealgas=False, use_eos=None, parameter_ref='default')`
+### `__init__(self, comps, mole_weights=None, sigma=None, eps_div_k=None, la=None, lr=None, lij=0, kij=0, N=4, is_idealgas=False, use_eos=None, parameter_ref='default', use_default_eos_param=False)`
 If parameters are explicitly supplied through optional arguments, these will be used instead of those in the database.
 To supply specific parameters for only some components, give `None` for the components that should use the database
 value
@@ -64,7 +71,52 @@ value
 
 &nbsp;&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp;  Mixing parameter for epsilon (kij > 0 => favours mixing, kij < 0 => favours separation)
 
-&nbsp;&nbsp;&nbsp;&nbsp; **use_eos :** 
+&nbsp;&nbsp;&nbsp;&nbsp; **use_eos (thermopack eos object, optional) :** 
 
-&nbsp;&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp;  (thermopack eos object, optional) EoS to use (initialized), defaults to `saftvrmie` 
+&nbsp;&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp;  EoS to use (initialized), defaults to `saftvrmie`
+
+&nbsp;&nbsp;&nbsp;&nbsp; **use_default_eos_param (bool) :** 
+
+&nbsp;&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp;  If `False` (default), ensure that the EoS and RET-model use the same parameters(if applicable). If `False`, do not forward specified parameters to the EoS.  
+
+## Utility methods
+
+Set- and get methods for interaction parameters, mixing parameters ...
+
+### Table of contents
+  * [Utility methods](#utility-methods)
+    * [set_eps_div_k](#set_eps_div_kself-eps_div_k-update_eostrue)
+    * [set_la](#set_laself-la-update_eostrue)
+    * [set_lr](#set_lrself-lr-update_eostrue)
+    * [set_sigma](#set_sigmaself-sigma-update_eostrue)
+
+
+### `set_eps_div_k(self, eps_div_k, update_eos=True)`
+See MieType
+ 
+
+### `set_la(self, la, update_eos=True)`
+See MieType
+ 
+
+### `set_lr(self, lr, update_eos=True)`
+See MieType
+ 
+
+### `set_sigma(self, sigma, update_eos=True)`
+See MieType
+ 
+
+## Internal methods
+
+Internal methods are not intended for use by end-users.
+
+### Table of contents
+  * [Internal methods](#internal-methods)
+    * [\_\_update_cpp_kingas_param\_\_](#__update_cpp_kingas_param__self)
+
+
+### `__update_cpp_kingas_param__(self)`
+See MieType
+ 
 

--- a/docs/vCurrent/MieType_methods.md
+++ b/docs/vCurrent/MieType_methods.md
@@ -6,7 +6,7 @@ permalink: /vcurrent/MieType_methods.html
 ---
 
 <!--- 
-Generated at: 2023-11-06T12:02:00.296431
+Generated at: 2024-04-18T17:31:55.382397
 This is an auto-generated file, generated using the script at KineticGas/pyUtils/markdown_from_docstrings.py
 The file is created by parsing the docstrings of the methods in the 
 MieType class. For instructions on how to use the parser routines, see the
@@ -22,8 +22,13 @@ Mie-Type Model. This class implements utility methods to access mixing parameter
     * [get_epsilon_matrix](#get_epsilon_matrixself-eps_div_k-kij)
     * [get_lambda_matrix](#get_lambda_matrixself-lambdas-lij)
     * [get_sigma_matrix](#get_sigma_matrixself-sigma)
-  * [Deprecated methods](#deprecated-methods)
-    * [get_avg_R](#get_avg_rself-t-x)
+    * [set_eps_div_k](#set_eps_div_kself-eps_div_k-update_eostrue)
+    * [set_la](#set_laself-la-update_eostrue)
+    * [set_lr](#set_lrself-lr-update_eostrue)
+    * [set_sigma](#set_sigmaself-sigma-update_eostrue)
+  * [Internal methods](#internal-methods)
+    * [\_\_update_cpp_kingas_param\_\_](#__update_cpp_kingas_param__self)
+    * [\_\_update_eos_param\_\_](#__update_eos_param__self)
 
 ## Constructor
 
@@ -78,6 +83,10 @@ Set- and get methods for interaction parameters, mixing parameters ...
     * [get_epsilon_matrix](#get_epsilon_matrixself-eps_div_k-kij)
     * [get_lambda_matrix](#get_lambda_matrixself-lambdas-lij)
     * [get_sigma_matrix](#get_sigma_matrixself-sigma)
+    * [set_eps_div_k](#set_eps_div_kself-eps_div_k-update_eostrue)
+    * [set_la](#set_laself-la-update_eostrue)
+    * [set_lr](#set_lrself-lr-update_eostrue)
+    * [set_sigma](#set_sigmaself-sigma-update_eostrue)
 
 
 ### `get_epsilon_matrix(self, eps_div_k, kij)`
@@ -122,7 +131,7 @@ Compute pair-interaction $\lambda_r$ parameters, apply mixing parameter.
 &nbsp;&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp;  Repulsive exponent for each pair-interaction. 
 
 ### `get_sigma_matrix(self, sigma)`
-Compute interaction parameter $sigma$ for each particle pair, applying mixing parameters given by `self.lij`.
+Compute interaction parameter $\sigma$ for each particle pair, applying mixing parameters given by `self.lij`.
 Warning: Use of mixing parameters is not thouroughly tested.
  
 
@@ -144,15 +153,62 @@ Warning: Use of mixing parameters is not thouroughly tested.
 
 &nbsp;&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp;  Use of mixing parameters is not thouroughly tested.  
 
-## Deprecated methods
+### `set_eps_div_k(self, eps_div_k, update_eos=True)`
+Set the well depth parameter. Note: Running with `update_eos=False` will result in a model using
+different parameters for collision integrals and the RDF than for the equation of state.
 
-Deprecated methods are not maintained, and may be removed in the future.
+Args:
+eps_div_k (list[float or None]) : Well depth parameter for each pure component. Use `None` for default values. Unit (K).
+update_eos (bool) : If True (default) also update the eos.
+ 
+
+### `set_la(self, la, update_eos=True)`
+Set the attractive exponent. Note: Running with `update_eos=False` will result in a model using
+different parameters for collision integrals and the RDF than for the equation of state.
+
+Args:
+la (list[float or None]) : Attractive exponent for each pure component. Use `None` for default values.
+update_eos (bool) : If True (default) also update the eos.
+ 
+
+### `set_lr(self, lr, update_eos=True)`
+Set the repulsive exponent. Note: Running with `update_eos=False` will result in a model using
+different parameters for collision integrals and the RDF than for the equation of state.
+
+Args:
+lr (list[float or None]) : Repulsive exponent for each pure component. Use `None` for default values.
+update_eos (bool) : If True (default) also update the eos.
+ 
+
+### `set_sigma(self, sigma, update_eos=True)`
+Set the size parameter. Note: Running with `update_eos=False` will result in a model using
+different parameters for collision integrals and the RDF than for the equation of state.
+
+Args:
+sigma (list[float or None]) : Size parameter for each pure component. Use `None` for default values. Unit (m).
+update_eos (bool) : If True (default) also update the eos.
+ 
+
+## Internal methods
+
+Internal methods are not intended for use by end-users.
 
 ### Table of contents
-  * [Deprecated methods](#deprecated-methods)
-    * [get_avg_R](#get_avg_rself-t-x)
+  * [Internal methods](#internal-methods)
+    * [\_\_update_cpp_kingas_param\_\_](#__update_cpp_kingas_param__self)
+    * [\_\_update_eos_param\_\_](#__update_eos_param__self)
 
 
-### `get_avg_R(self, T, x)`
+### `__update_cpp_kingas_param__(self)`
+Re-Initialize the C++ module with the current parameters in this model. Inheriting classes are responsible
+for initializing the correct model.
+ 
+
+### `__update_eos_param__(self)`
+Update the EoS model to use the same parameters as this model is currently set with.
+
+Raises:
+AttributeError : If the EoS object does not support setting parameters
+Warning : If the EoS object is using segment numbers different from 1.
  
 

--- a/docs/vCurrent/py_KineticGas_methods.md
+++ b/docs/vCurrent/py_KineticGas_methods.md
@@ -6,7 +6,7 @@ permalink: /vcurrent/py_KineticGas_methods.html
 ---
 
 <!--- 
-Generated at: 2024-04-16T15:54:30.853573
+Generated at: 2024-04-18T17:57:40.002828
 This is an auto-generated file, generated using the script at KineticGas/pyUtils/markdown_from_docstrings.py
 The file is created by parsing the docstrings of the methods in the 
 py_KineticGas class. For instructions on how to use the parser routines, see the
@@ -31,7 +31,7 @@ The `py_KineticGas` class, found in `pykingas/py_KineticGas.py`, is the core of 
     * [viscosity](#viscosityself-t-vm-x-nnone)
   * [Tp-property interfaces](#tp-property-interfaces)
     * [interdiffusion_tp](#interdiffusion_tpself-t-p-x-nnone-use_independenttrue-dependent_idxnone-frame_of_referencecon-use_binarytrue-solvent_idxnone)
-    * [thermal_coductivity_tp](#thermal_coductivity_tpself-t-p-x-nnone)
+    * [thermal_conductivity_tp](#thermal_conductivity_tpself-t-p-x-nnone)
     * [thermal_diffusion_coeff_tp](#thermal_diffusion_coeff_tpself-t-p-x-nnone-use_independentfalse-dependent_idxnone-frame_of_referencecon-solvent_idxnone)
     * [thermal_diffusion_factor_tp](#thermal_diffusion_factor_tpself-t-p-x-nnone)
     * [viscosity_tp](#viscosity_tpself-t-p-x-nnone)
@@ -58,6 +58,8 @@ The `py_KineticGas` class, found in `pykingas/py_KineticGas.py`, is the core of 
     * [get_Eij](#get_eijself-vm-t-x)
     * [get_P_factors](#get_p_factorsself-vm-t-x)
     * [reshape_diffusion_coeff_vector](#reshape_diffusion_coeff_vectorself-d)
+  * [Deprecated methods](#deprecated-methods)
+    * [thermal_coductivity_tp](#thermal_coductivity_tpself-t-p-x-nnone)
 
 ## The constructor
 
@@ -550,7 +552,7 @@ Computing properties as a function of temperature and pressure. Simply forwards 
 ### Table of contents
   * [Tp-property interfaces](#tp-property-interfaces)
     * [interdiffusion_tp](#interdiffusion_tpself-t-p-x-nnone-use_independenttrue-dependent_idxnone-frame_of_referencecon-use_binarytrue-solvent_idxnone)
-    * [thermal_coductivity_tp](#thermal_coductivity_tpself-t-p-x-nnone)
+    * [thermal_conductivity_tp](#thermal_conductivity_tpself-t-p-x-nnone)
     * [thermal_diffusion_coeff_tp](#thermal_diffusion_coeff_tpself-t-p-x-nnone-use_independentfalse-dependent_idxnone-frame_of_referencecon-solvent_idxnone)
     * [thermal_diffusion_factor_tp](#thermal_diffusion_factor_tpself-t-p-x-nnone)
     * [viscosity_tp](#viscosity_tpself-t-p-x-nnone)
@@ -561,7 +563,7 @@ Compute molar volume using the internal equation of state (`self.eos`), assuming
 `self.interdiffusion`. See `self.interdiffusion` for documentation.
  
 
-### `thermal_coductivity_tp(self, T, p, x, N=None)`
+### `thermal_conductivity_tp(self, T, p, x, N=None)`
 Compute molar volume using the internal equation of state (`self.eos`), assuming vapour, and pass the call to
 `self.thermal_conductivity`. See `self.thermal_conductivity` for documentation.
  
@@ -1160,4 +1162,17 @@ as `d[i][q][j]` where i and j are component indices, and q refferes to the appro
 &nbsp;&nbsp;&nbsp;&nbsp; **3D array :** 
 
 &nbsp;&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp;  The matrix of $d_{i, j}^{(q)}$ coefficients ordered as `d[i][q][j]` 
+
+## Deprecated methods
+
+Deprecated methods are not maintained, and may be removed in the future.
+
+### Table of contents
+  * [Deprecated methods](#deprecated-methods)
+    * [thermal_coductivity_tp](#thermal_coductivity_tpself-t-p-x-nnone)
+
+
+### `thermal_coductivity_tp(self, T, p, x, N=None)`
+Slightly embarrasing typo in method name... Keeping alive for a while because some code out there uses this one.
+ 
 

--- a/pyUtils/markdown_from_docstrings.py
+++ b/pyUtils/markdown_from_docstrings.py
@@ -175,6 +175,7 @@ def split_methods_by_section(sections, methods):
 
     if 'deprecated' not in [s.lower() for s in sections]:
         sections.append('Deprecated')
+        sections.append('Internal')
 
     method_dict = {}
     for name, meth in methods:
@@ -223,6 +224,14 @@ def get_automatic_sections(sections, section_headers, section_intro, method_dict
             section_headers['Deprecated'] = 'Deprecated methods'
         if 'Deprecated' not in section_intro.keys():
             section_intro['Deprecated'] = 'Deprecated methods are not maintained, and may be removed in the future.'
+
+    if 'Internal' in method_dict.keys():
+        if 'Internal' not in sections:
+            sections.append('Internal')
+        if 'Internal' not in section_headers.keys():
+            section_headers['Internal'] = 'Internal methods'
+        if 'Internal' not in section_intro.keys():
+            section_intro['Internal'] = 'Internal methods are not intended for use by end-users.'
 
     return sections, section_headers, section_intro
 
@@ -387,7 +396,6 @@ def miekingas_to_markdown():
     class_methods = inspect.getmembers(MieKinGas, predicate=inspect.isfunction)
     parent_methods = inspect.getmembers(MieType, predicate=inspect.isfunction)
     specific_methods = sorted(list(set(class_methods) - set(parent_methods)))
-
     basic_class_to_markdown(classname, eosname, specific_methods, inherits='MieType')
 
 def hardsphere_to_markdown():

--- a/pykingas/MieType.py
+++ b/pykingas/MieType.py
@@ -10,6 +10,8 @@ from scipy.constants import Boltzmann, Avogadro
 from scipy.integrate import quad
 from pykingas.py_KineticGas import py_KineticGas
 from warnings import warn
+from thermopack.saft import saft
+import abc
 
 class MieType(py_KineticGas):
 
@@ -45,45 +47,21 @@ class MieType(py_KineticGas):
                          stacklevel=2)
             raise KeyError('Missing parameters ' + parameter_ref + ' for compontents ' + comps)
 
-        if eps_div_k is None:
-            eps_div_k = [self.fluids[i]['eps_div_k'] for i in range(self.ncomps)]
-        elif None in eps_div_k:
-            for i in range(self.ncomps):
-                if eps_div_k[i] is None:
-                    eps_div_k[i] = self.fluids[i]['eps_div_k']
-        elif self._is_singlecomp is True:
-            eps_div_k = [eps_div_k[0] for _ in range(2)]
-        eps_div_k = np.array(eps_div_k)
-        assert eps_div_k.shape == (self.ncomps,)
-        self.epsilon_ij = self.get_epsilon_matrix(eps_div_k, kij)
-        self.epsilon = np.diag(self.epsilon_ij)
+        self.sigma, self.sigma_ij, self.epsilon, self.epsilon_ij, self.la, self.lr = [None] * 6
+        MieType.set_eps_div_k(self, eps_div_k, update_eos=False)
+        MieType.set_la(self, la, update_eos=False)
+        MieType.set_lr(self, lr, update_eos=False)
+        MieType.set_sigma(self, sigma, update_eos=False)
+    
+    def set_sigma(self, sigma, update_eos=True):
+        """Utility
+        Set the size parameter. Note: Running with `update_eos=False` will result in a model using
+        different parameters for collision integrals and the RDF than for the equation of state.
 
-        if la is None:
-            la = [self.fluids[i]['lambda_a'] for i in range(self.ncomps)]
-        elif None in la:
-            for i in range(self.ncomps):
-                if la[i] is None:
-                    la[i] = self.fluids[i]['lambda_a']
-        elif self._is_singlecomp is True:
-            la = [la[0] for _ in range(2)]
-
-        la = np.array(la)
-        assert la.shape == (self.ncomps,)
-        self.la = self.get_lambda_matrix(la, 0)
-
-        if lr is None:
-            lr = [self.fluids[i]['lambda_r'] for i in range(self.ncomps)]
-        elif None in lr:
-            for i in range(self.ncomps):
-                if lr[i] is None:
-                    lr[i] = self.fluids[i]['lambda_r']
-        elif self._is_singlecomp is True:
-            lr = [lr[0] for _ in range(2)]
-
-        lr = np.array(lr)
-        assert lr.shape == (self.ncomps,)
-        self.lr = self.get_lambda_matrix(lr, self.lij)
-
+        Args:
+            sigma (list[float or None]) : Size parameter for each pure component. Use `None` for default values. Unit (m).
+            update_eos (bool) : If True (default) also update the eos.
+        """
         if sigma is None:
             sigma = [self.fluids[i]['sigma'] for i in range(self.ncomps)]
         elif None in sigma:
@@ -97,25 +75,118 @@ class MieType(py_KineticGas):
         assert sigma.shape == (self.ncomps,)
         self.sigma_ij = self.get_sigma_matrix(sigma)
         self.sigma = self.sigma_ij
+        
+        if update_eos is True:
+            self.__update_eos_param__()
+    
+    def set_lr(self, lr, update_eos=True):
+        """Utility
+        Set the repulsive exponent. Note: Running with `update_eos=False` will result in a model using
+        different parameters for collision integrals and the RDF than for the equation of state.
 
-    def get_avg_R(self, T, x):
-        """Deprecated
+        Args:
+            lr (list[float or None]) : Repulsive exponent for each pure component. Use `None` for default values.
+            update_eos (bool) : If True (default) also update the eos.
         """
-        warn("This method will be removed. Does not do anything exciting.", DeprecationWarning)
-        v_bar_1 = np.sqrt(3 * Boltzmann * T / self.mole_weights[0]) * np.sqrt(
-            self.m0 * self.M[0] * self.M[1] / (2 * Boltzmann * T))
-        v_bar_2 = np.sqrt(3 * Boltzmann * T / self.mole_weights[1]) * np.sqrt(
-            self.m0 * self.M[0] * self.M[1] / (2 * Boltzmann * T))
+        if lr is None:
+            lr = [self.fluids[i]['lambda_r'] for i in range(self.ncomps)]
+        elif None in lr:
+            for i in range(self.ncomps):
+                if lr[i] is None:
+                    lr[i] = self.fluids[i]['lambda_r']
+        elif self._is_singlecomp is True:
+            lr = [lr[0] for _ in range(2)]
 
-        v_min = min(v_bar_1 - v_bar_2, v_bar_2 - v_bar_1)
-        v_max = v_bar_1 + v_bar_2
-        v_bar_12 = (v_bar_1 + v_bar_2) / 2
-        R_11 = quad(lambda b: self.cpp_kingas.get_R(0, 0, T, v_bar_1, b), 0, self.sigma_ij[0, 0])[0] / self.sigma_ij[0, 0]
-        R_12 = quad(lambda b: self.cpp_kingas.get_R(0, 1, T, v_bar_12, b), 0, self.sigma_ij[0, 1])[0] / self.sigma_ij[
-            0, 1]
-        R_22 = quad(lambda b: self.cpp_kingas.get_R(1, 1, T, v_bar_2, b), 0, self.sigma_ij[1, 1])[0] / self.sigma_ij[1, 1]
+        lr = np.array(lr)
+        assert lr.shape == (self.ncomps,)
+        self.lr = self.get_lambda_matrix(lr, self.lij)
+        
+        if update_eos is True:
+            self.__update_eos_param__()
+    
+    def set_la(self, la, update_eos=True):
+        """Utility
+        Set the attractive exponent. Note: Running with `update_eos=False` will result in a model using
+        different parameters for collision integrals and the RDF than for the equation of state.
 
-        return x[0] ** 2 * R_11 + 2 * x[0] * x[1] * R_12 + x[1] ** 2 * R_22
+        Args:
+            la (list[float or None]) : Attractive exponent for each pure component. Use `None` for default values.
+            update_eos (bool) : If True (default) also update the eos.
+        """
+        if la is None:
+            la = [self.fluids[i]['lambda_a'] for i in range(self.ncomps)]
+        elif None in la:
+            for i in range(self.ncomps):
+                if la[i] is None:
+                    la[i] = self.fluids[i]['lambda_a']
+        elif self._is_singlecomp is True:
+            la = [la[0] for _ in range(2)]
+
+        la = np.array(la)
+        assert la.shape == (self.ncomps,)
+        self.la = self.get_lambda_matrix(la, 0)
+        
+        if update_eos is True:
+            self.__update_eos_param__()
+    
+    def set_eps_div_k(self, eps_div_k, update_eos=True):
+        """Utility
+        Set the well depth parameter. Note: Running with `update_eos=False` will result in a model using
+        different parameters for collision integrals and the RDF than for the equation of state.
+
+        Args:
+            eps_div_k (list[float or None]) : Well depth parameter for each pure component. Use `None` for default values. Unit (K).
+            update_eos (bool) : If True (default) also update the eos.
+        """
+        if eps_div_k is None:
+            eps_div_k = [self.fluids[i]['eps_div_k'] for i in range(self.ncomps)]
+        elif None in eps_div_k:
+            for i in range(self.ncomps):
+                if eps_div_k[i] is None:
+                    eps_div_k[i] = self.fluids[i]['eps_div_k']
+        elif self._is_singlecomp is True:
+            eps_div_k = [eps_div_k[0] for _ in range(2)]
+        eps_div_k = np.array(eps_div_k)
+        assert eps_div_k.shape == (self.ncomps,)
+        self.epsilon_ij = self.get_epsilon_matrix(eps_div_k, self.kij)
+        self.epsilon = np.diag(self.epsilon_ij)
+        
+        if update_eos is True:
+            self.__update_eos_param__()
+    
+    def __update_eos_param__(self):
+        """Internal
+        Update the EoS model to use the same parameters as this model is currently set with.
+
+        Raises:
+            AttributeError : If the EoS object does not support setting parameters
+            Warning : If the EoS object is using segment numbers different from 1.
+        """
+        if (self.eos is None) or (self.is_idealgas is True):
+            return
+
+        if not isinstance(self.eos, saft):
+            raise AttributeError(f"Model EoS object ({self.eos}) does not support setting potential parameters!")
+        
+        if self._is_singlecomp:
+            set_ncomps = 1
+        else:
+            set_ncomps = self.ncomps
+        
+        for i in range(set_ncomps):
+            segment_number = self.eos.get_pure_fluid_param(i + 1)[0]
+            if segment_number != 1:
+                warn(f"Current EoS uses segment number {segment_number} != 1 for component {self.comps[i]}", Warning, stacklevel=2)
+            params = (segment_number, self.sigma[i][i], self.epsilon[i] / Boltzmann, self.la[i][i], self.lr[i][i])
+            self.eos.set_pure_fluid_param(i + 1, *params)
+
+    @abc.abstractmethod
+    def __update_cpp_kingas_param__(self):
+        """Internal
+        Re-Initialize the C++ module with the current parameters in this model. Inheriting classes are responsible
+        for initializing the correct model.
+        """
+        pass
 
     def get_epsilon_matrix(self, eps_div_k, kij):
         """Utility
@@ -135,8 +206,8 @@ class MieType(py_KineticGas):
             epsilon * np.vstack(epsilon))  # Only apply mixing parameter kij to the off-diagonals
 
     def get_sigma_matrix(self, sigma):
-        """Utility
-        Compute interaction parameter $sigma$ for each particle pair, applying mixing parameters given by `self.lij`.
+        r"""Utility
+        Compute interaction parameter $\sigma$ for each particle pair, applying mixing parameters given by `self.lij`.
         Warning: Use of mixing parameters is not thouroughly tested.
         &&
         Args:
@@ -154,7 +225,7 @@ class MieType(py_KineticGas):
         return sigma_ij
 
     def get_lambda_matrix(self, lambdas, lij):
-        """Utility
+        r"""Utility
         Compute pair-interaction $\lambda_r$ parameters, apply mixing parameter.
         &&
         Args:

--- a/pykingas/py_KineticGas.py
+++ b/pykingas/py_KineticGas.py
@@ -192,7 +192,7 @@ class py_KineticGas:
         if self._is_singlecomp is True:
             _, dmudn_pure = self.eos.chemical_potential_tv(T, Vm, [1.], dmudn=True)
             RT = Avogadro * Boltzmann * T
-            dmudrho_pure = Vm * dmudn_pure
+            dmudrho_pure = Vm * dmudn_pure[0][0]
             dmudrho = np.zeros((2, 2))
             rho = 1 / Vm
             dmudrho[0, 0] = dmudrho_pure + RT * x[1] / (rho * x[0])
@@ -502,7 +502,7 @@ class py_KineticGas:
 
         key = tuple((T, Vm, tuple(x), N))
         if key in self.computed_kT.keys():
-            return self.computed_kT[key]
+            return np.array(self.computed_kT[key])
 
         if N < 2:
             warnings.warn('Thermal diffusion is a 2nd order phenomena, cannot be computed for N < 2 (got N = '
@@ -847,6 +847,14 @@ class py_KineticGas:
         return self.thermal_diffusion_factor(T, Vm, x, N=N)
 
     def thermal_coductivity_tp(self, T, p, x, N=None):
+        """Deprecated
+        Slightly embarrasing typo in method name... Keeping alive for a while because some code out there uses this one.
+        """
+        warnings.warn('This method will be removed! Use thermal_conductivity_tp. (Note the missing "N")', DeprecationWarning)
+        Vm, = self.eos.specific_volume(T, p, x, self.eos.VAPPH)  # Assuming vapour phase
+        return self.thermal_conductivity(T, Vm, x, N=N)
+
+    def thermal_conductivity_tp(self, T, p, x, N=None):
         """Tp-property
         Compute molar volume using the internal equation of state (`self.eos`), assuming vapour, and pass the call to
         `self.thermal_conductivity`. See `self.thermal_conductivity` for documentation.

--- a/pykingas/py_KineticGas.py
+++ b/pykingas/py_KineticGas.py
@@ -190,13 +190,14 @@ class py_KineticGas:
                                 is the molar density of species $i$. Unit [1 / mol]
         """
         if self._is_singlecomp is True:
-            x = [0.5, 0.5]
-            _, dmudn_pure = self.eos.chemical_potential_tv(T, Vm, [0.5], dmudn=True)
+            _, dmudn_pure = self.eos.chemical_potential_tv(T, Vm, [1.], dmudn=True)
+            RT = Avogadro * Boltzmann * T
             dmudrho_pure = Vm * dmudn_pure
             dmudrho = np.zeros((2, 2))
             rho = 1 / Vm
-            dmudrho[0, 0] = dmudrho[1, 1] = dmudrho_pure + Avogadro * Boltzmann * T / rho
-            dmudrho[0, 1] = dmudrho[1, 0] = dmudrho_pure - Avogadro * Boltzmann * T / rho
+            dmudrho[0, 0] = dmudrho_pure + RT * x[1] / (rho * x[0])
+            dmudrho[0, 1] = dmudrho[1, 0] = dmudrho_pure - RT / rho
+            dmudrho[1, 1] = dmudrho_pure + RT * x[0] / (rho * x[1])
             dmudrho /= Avogadro
         else:
             _, dmudn = self.eos.chemical_potential_tv(T, Vm, x, dmudn=True)

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -51,7 +51,7 @@ def test_singlecomp_binary(m, sigma, eps_div_k, la, lr):
     Test that initializing a single component, and a binary mixture of identical species gives the same output.
     See: PR #27
     """
-    kin1 = MieKinGas('AR', mole_weights=[m * Avogadro * 1e3, m * Avogadro * 1e3], sigma=[sigma, sigma],
+    kin1 = MieKinGas('LJF', mole_weights=[m * Avogadro * 1e3, m * Avogadro * 1e3], sigma=[sigma, sigma],
                      eps_div_k=[eps_div_k, eps_div_k], la=[la, la], lr=[lr, lr])
     kin2 = MieKinGas('AR,KR', mole_weights=[m * Avogadro * 1e3, m * Avogadro * 1e3],
                      sigma=[sigma, sigma], eps_div_k=[eps_div_k, eps_div_k], la=[la, la], lr=[lr, lr])


### PR DESCRIPTION
Init now ensures that the equation of state uses the same parameters as the RET model (if applicable). This means that the models

```
kin1 = MieKinGas('AR', mole_weights=[m * Avogadro * 1e3, m * Avogadro * 1e3], sigma=[sigma, sigma], eps_div_k=[eps_div_k, eps_div_k], la=[6, 6], lr=[lr, lr])
kin2 = MieKinGas('AR,KR', mole_weights=[m * Avogadro * 1e3, m * Avogadro * 1e3],
                 sigma=[sigma, sigma], eps_div_k=[eps_div_k, eps_div_k], la=[6, 6], lr=[lr, lr])
```
will give identical output, as expected.

Made some modifications to `get_Eij`, which ensures that the output is the same for a single component mixture, and a binary mixture of identical components, also if `x != [0.5, 0.5]`, which is the expected behaviour. Previously, pure fluid calculation in `get_Eij` used a hardcoded value of `x=[0.5, 0.5]`, which could lead to confusing output when testing the method.
